### PR TITLE
Dynamic amount of visits for URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-login-links` will be documented in this file.
 
+## 1.0.0 - 2021-08-11
+- Replaced `expire_after_visit` with `allowed_visits_before_expiration` config value.
+Users can now specify how many times a URL can be visited before it expires.
+- Added `visits` and `visits_allowed` to migration
+- Updated tests
+- Updated README.md
+
 ## 0.30 - 2021-07-11
 - Added `generateLoginLink()` method for classes that have `CanLoginWithLink` trait.
 - Added tests for `generateLoginLink()`

--- a/config/login-links.php
+++ b/config/login-links.php
@@ -22,11 +22,10 @@ return [
         'redirect_after_login' => '/',
 
         /**
-         * If the token should expire after the first visit.
-         * If set to true you must run the migration for the one_time_logins table.
-         * If set to false the link can be used until it is expired.
+         * After how many visits the token should expire
+         * After the specified amount visits, the token is immediately deleted from the database.
          */
-        'expire_after_visit' => true,
+        'allowed_visits_before_expiration' => 1,
 
         /**
          * Extra middleware you would like to add to the route

--- a/database/migrations/2021_07_07_120000_create_login_link_tokens_table.php
+++ b/database/migrations/2021_07_07_120000_create_login_link_tokens_table.php
@@ -11,6 +11,8 @@ class CreateLoginLinkTokensTable extends Migration
         Schema::create('login_link_tokens', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->text('url');
+            $table->integer('visits')->default(0);
+            $table->integer('visits_allowed')->default(1);
             $table->timestamps();
         });
     }

--- a/src/Commands/LoginLinkCleanupCommand.php
+++ b/src/Commands/LoginLinkCleanupCommand.php
@@ -7,7 +7,7 @@ use Koost89\LoginLinks\Models\LoginLinkToken;
 
 class LoginLinkCleanupCommand extends Command
 {
-    public $signature = 'uli:cleanup';
+    public $signature = 'login-links:cleanup';
 
     public $description = 'Cleans up all the expired tokens in the database.';
 

--- a/src/Commands/LoginLinkCreateCommand.php
+++ b/src/Commands/LoginLinkCreateCommand.php
@@ -7,7 +7,7 @@ use Koost89\LoginLinks\LoginLink;
 
 class LoginLinkCreateCommand extends Command
 {
-    public $signature = 'uli:create {id} {--class=App\Models\User}';
+    public $signature = 'login-links:generate {id} {--class=App\Models\User}';
 
     public $description = 'Generate a signed login url for a specific user.';
 

--- a/src/Http/Controllers/LoginUsingLink.php
+++ b/src/Http/Controllers/LoginUsingLink.php
@@ -13,14 +13,12 @@ class LoginUsingLink extends Controller
 {
     public function __invoke(Request $request, LoginLink $loginLink): RedirectResponse
     {
-        if ($loginLink->shouldExpireAfterVisit()) {
-            $loginToken = LoginLinkToken::where('url', $request->getSchemeAndHttpHost() . $request->getRequestUri())
-                ->firstOrFail();
-        }
-
         $class = URLHelper::encodedStringToClass($request->auth_type);
 
-        $loginLink->login($request->auth_id, $class, $loginToken ?? null);
+        $loginToken = LoginLinkToken::where('url', $request->getSchemeAndHttpHost() . $request->getRequestUri())
+            ->firstOrFail();
+
+        $loginLink->login($request->auth_id, $class, $loginToken);
 
         return redirect()->to(config('login-links.route.redirect_after_login'));
     }

--- a/src/LoginLink.php
+++ b/src/LoginLink.php
@@ -48,7 +48,7 @@ class LoginLink
     {
         LoginLinkToken::create([
             'url' => $url,
-            'visits_allowed' => $visits_allowed
+            'visits_allowed' => $visits_allowed,
         ]);
     }
 

--- a/src/LoginLink.php
+++ b/src/LoginLink.php
@@ -20,18 +20,17 @@ class LoginLink
             'auth_type' => URLHelper::classToEncodedString(get_class($authenticatable)),
         ]);
 
-        if ($this->shouldExpireAfterVisit()) {
-            LoginLinkToken::create(['url' => $url]);
-        }
+        $this->handleTokenCreation($url, $authenticatable->getAllowedVisits());
 
         LoginLinkGenerated::dispatch($authenticatable->id, get_class($authenticatable));
 
         return $url;
     }
 
-    public function login($authId, $class, $userLoginToken = null)
+    public function login($authId, string $class, LoginLinkToken $loginLinkToken): void
     {
-        $guard = (new $class)->getGuardName();
+        $authenticatable = new $class;
+        $guard = $authenticatable->getGuardName();
 
         if (method_exists(Auth::guard($guard), 'login')) {
             Auth::guard($guard)
@@ -40,29 +39,37 @@ class LoginLink
             LoginLinkUsed::dispatch($authId, $class);
         }
 
-        if ($this->shouldExpireAfterVisit()) {
-            $this->deleteLoginToken($userLoginToken);
+        if ($authenticatable->hasVisitLimit()) {
+            $this->handleTokenVisits($loginLinkToken);
         }
     }
 
-    public function shouldExpireAfterVisit()
+    protected function handleTokenCreation($url, $visits_allowed): void
     {
-        return config('login-links.route.expire_after_visit');
+        LoginLinkToken::create([
+            'url' => $url,
+            'visits_allowed' => $visits_allowed
+        ]);
+    }
+
+    protected function handleTokenVisits(LoginLinkToken $loginLinkToken): ?bool
+    {
+        if (! $loginLinkToken) {
+            return true;
+        }
+
+        $loginLinkToken->visits++;
+
+        if ($loginLinkToken->hasExceededVisitLimit()) {
+            return $loginLinkToken->delete();
+        }
+
+        return $loginLinkToken->save();
     }
 
     protected function generateUrl(array $params): string
     {
         return URL::temporarySignedRoute('login-links.login', $this->createExpiration(), $params);
-    }
-
-    protected function getGuardFromClass($class)
-    {
-        return (new $class)->getGuardName();
-    }
-
-    protected function deleteLoginToken($userLoginToken): void
-    {
-        $userLoginToken->delete();
     }
 
     protected function createExpiration(): Carbon

--- a/src/Models/LoginLinkToken.php
+++ b/src/Models/LoginLinkToken.php
@@ -7,5 +7,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class LoginLinkToken extends Model
 {
-    protected $fillable = ['url'];
+    protected $fillable = ['url', 'visits_allowed'];
+
+    public function hasExceededVisitLimit()
+    {
+        return $this->visits >= $this->visits_allowed;
+    }
 }

--- a/src/Traits/CanLoginWithLink.php
+++ b/src/Traits/CanLoginWithLink.php
@@ -12,7 +12,17 @@ trait CanLoginWithLink
         return config('login-links.auth.guard');
     }
 
-    public function generateLoginLink()
+    public function hasVisitLimit(): bool
+    {
+        return $this->getAllowedVisits() > 0;
+    }
+
+    public function getAllowedVisits()
+    {
+        return config('login-links.route.allowed_visits_before_expiration');
+    }
+
+    public function generateLoginLink(): string
     {
         return LoginLink::generate($this);
     }

--- a/tests/Commands/LoginLinkCleanupCommandTest.php
+++ b/tests/Commands/LoginLinkCleanupCommandTest.php
@@ -31,7 +31,7 @@ class LoginLinkCleanupCommandTest extends TestCase
 
     public function test_it_uses_the_config_for_expiration_threshold()
     {
-        $this->app['config']->set('login-links.route.expiration', 1);
+        config()->set('login-links.route.expiration', 1);
 
         $this->createOneTimeLoginTokenRecord(now()->subMinute());
 
@@ -42,7 +42,7 @@ class LoginLinkCleanupCommandTest extends TestCase
 
     public function test_the_expiration_can_support_longer_times()
     {
-        $this->app['config']->set('login-links.route.expiration', 60 * 60 * 24 * 7);
+        config()->set('login-links.route.expiration', 60 * 60 * 24 * 7);
 
         $this->createOneTimeLoginTokenRecord(now()->subDays(6));
 

--- a/tests/CustomConfigTest.php
+++ b/tests/CustomConfigTest.php
@@ -11,10 +11,10 @@ class CustomConfigTest extends TestCase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('login-links.route', [
+        config()->set('login-links.route', [
            'path' => '/custom-route',
            'redirect_after_login' => '/test-redirect',
-           'expire_after_visit' => false,
+           'allowed_visits_before_expiration' => 0,
            'additional_middleware' => ['guest'],
        ]);
     }
@@ -30,18 +30,6 @@ class CustomConfigTest extends TestCase
         $url = LoginLink::generate(User::first());
         $this->get($url)
            ->assertRedirect('/test-redirect');
-    }
-
-    public function test_it_doesnt_need_a_db_table_when_expire_after_visit_is_false()
-    {
-        $this->app['db']->connection()->getSchemaBuilder()->drop('login_link_tokens');
-
-        $user = User::first();
-        $url = LoginLink::generate($user);
-
-        $this->get($url);
-
-        $this->assertAuthenticatedAs($user);
     }
 
     public function test_it_adds_the_specified_middleware()

--- a/tests/CustomGuardTest.php
+++ b/tests/CustomGuardTest.php
@@ -19,7 +19,7 @@ class CustomGuardTest extends TestCase
 
     public function test_the_generated_link_is_valid_for_custom_models()
     {
-        $this->app['config']->set('auth.providers.users.model', OtherAuthenticatable::class);
+//        config()->set('auth.providers.users.model', OtherAuthenticatable::class);
 
         $otherAuthenticatable = OtherAuthenticatable::inRandomOrder()->first();
 
@@ -31,7 +31,7 @@ class CustomGuardTest extends TestCase
 
     public function test_it_can_support_multiple_guards()
     {
-        $this->app['config']->set('auth.providers', [
+        config()->set('auth.providers', [
             'users' => [
                 'driver' => 'eloquent',
                 'model' => User::class,
@@ -42,7 +42,7 @@ class CustomGuardTest extends TestCase
             ],
         ]);
 
-        $this->app['config']->set('auth.guards', [
+        config()->set('auth.guards', [
             'web' => [
                 'driver' => 'session',
                 'provider' => 'users',

--- a/tests/Events/LoginLinkGeneratedTest.php
+++ b/tests/Events/LoginLinkGeneratedTest.php
@@ -4,9 +4,7 @@ namespace Koost89\LoginLinks\Tests\Events;
 
 use Illuminate\Support\Facades\Event;
 use Koost89\LoginLinks\Events\LoginLinkGenerated;
-use Koost89\LoginLinks\Facades\LoginLink;
 use Koost89\LoginLinks\Tests\TestCase;
-use Koost89\LoginLinks\Tests\TestClasses\User;
 
 class LoginLinkGeneratedTest extends TestCase
 {
@@ -14,7 +12,7 @@ class LoginLinkGeneratedTest extends TestCase
     {
         Event::fake();
 
-        LoginLink::generate(User::first());
+        $this->createUrlAndToken();
 
         Event::assertDispatched(LoginLinkGenerated::class);
     }
@@ -23,12 +21,10 @@ class LoginLinkGeneratedTest extends TestCase
     {
         Event::fake();
 
-        $user = User::first();
+        $data = $this->createUrlAndToken();
 
-        LoginLink::generate($user);
-
-        Event::assertDispatched(LoginLinkGenerated::class, function ($event) use ($user) {
-            return $event->id === $user->id && $event->class === get_class($user);
+        Event::assertDispatched(LoginLinkGenerated::class, function ($event) use ($data) {
+            return $event->id === $data->user->id && $event->class === get_class($data->user);
         });
     }
 }

--- a/tests/Events/LoginLinkUsedTest.php
+++ b/tests/Events/LoginLinkUsedTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Event;
 use Koost89\LoginLinks\Events\LoginLinkUsed;
 use Koost89\LoginLinks\Facades\LoginLink;
 use Koost89\LoginLinks\Tests\TestCase;
-use Koost89\LoginLinks\Tests\TestClasses\User;
 
 class LoginLinkUsedTest extends TestCase
 {
@@ -14,9 +13,9 @@ class LoginLinkUsedTest extends TestCase
     {
         Event::fake();
 
-        $url = LoginLink::generate(User::first());
+        $data = $this->createUrlAndToken();
 
-        $this->get($url);
+        LoginLink::login($data->user->id, get_class($data->user), $data->token);
 
         Event::assertDispatched(LoginLinkUsed::class);
     }
@@ -25,14 +24,12 @@ class LoginLinkUsedTest extends TestCase
     {
         Event::fake();
 
-        $user = User::first();
+        $data = $this->createUrlAndToken();
 
-        $url = LoginLink::generate($user);
+        LoginLink::login($data->user->id, get_class($data->user), $data->token);
 
-        $this->get($url);
-
-        Event::assertDispatched(LoginLinkUsed::class, function ($event) use ($user) {
-            return (int) $event->id === $user->id && $event->class === get_class($user);
+        Event::assertDispatched(LoginLinkUsed::class, function ($event) use ($data) {
+            return (int) $event->id === $data->user->id && $event->class === get_class($data->user);
         });
     }
 }

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -5,7 +5,6 @@ namespace Koost89\LoginLinks\Tests;
 use Koost89\LoginLinks\Facades\LoginLink;
 use Koost89\LoginLinks\Models\LoginLinkToken;
 use Koost89\LoginLinks\Tests\TestClasses\User;
-use TheSeer\Tokenizer\Token;
 
 class LoginTest extends TestCase
 {
@@ -88,6 +87,5 @@ class LoginTest extends TestCase
         LoginLink::login($data->user->id, get_class($data->user), $data->token->fresh());
 
         $this->assertAuthenticatedAs($data->user);
-
     }
 }

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -5,61 +5,89 @@ namespace Koost89\LoginLinks\Tests;
 use Koost89\LoginLinks\Facades\LoginLink;
 use Koost89\LoginLinks\Models\LoginLinkToken;
 use Koost89\LoginLinks\Tests\TestClasses\User;
+use TheSeer\Tokenizer\Token;
 
 class LoginTest extends TestCase
 {
     public function test_it_can_login_with_the_signed_url()
     {
-        $user = User::inRandomOrder()->first();
+        $data = $this->createUrlAndToken();
+        $this->get($data->url);
 
-        $url = LoginLink::generate($user);
-
-        $this->get($url);
-
-        $this->assertAuthenticatedAs($user);
+        $this->assertAuthenticatedAs($data->user);
     }
 
     public function test_it_redirects_after_login()
     {
-        $user = User::inRandomOrder()->first();
+        $data = $this->createUrlAndToken();
 
-        $url = LoginLink::generate($user);
-
-        $this->get($url)->assertRedirect(config('login-links.route.redirect_after_login'));
+        $this->get($data->url)
+            ->assertRedirect(config('login-links.route.redirect_after_login'));
     }
 
     public function test_it_stores_a_token_by_default()
     {
-        $user = User::inRandomOrder()->first();
-
-        LoginLink::generate($user);
-
+        $this->createUrl(User::inRandomOrder()->first());
         $this->assertEquals(1, LoginLinkToken::count());
     }
 
     public function test_if_configured_it_can_expire_after_a_single_login()
     {
-        $user = User::inRandomOrder()->first();
+        $data = $this->createUrlAndToken();
 
-        $url = LoginLink::generate($user);
-
-        $this->get($url);
+        LoginLink::login($data->user->id, get_class($data->user), $data->token);
 
         $this->assertEquals(0, LoginLinkToken::count());
     }
 
     public function test_the_user_cannot_login_after_the_link_expires()
     {
-        $this->app['config']->set('login-links.route.expiration', -10);
+        config()->set('login-links.route.expiration', -10);
 
-        $user = User::inRandomOrder()->first();
-
-        $url = LoginLink::generate($user);
+        $data = $this->createUrlAndToken();
 
         $this->followingRedirects()
-            ->get($url)
+            ->get($data->url)
             ->assertForbidden();
 
         $this->assertGuest();
+    }
+
+    public function test_the_amount_of_visits_is_increased_when_visiting_a_link()
+    {
+        config()->set('login-links.route.allowed_visits_before_expiration', 2);
+
+        $data = $this->createUrlAndToken();
+
+        LoginLink::login($data->user->id, get_class($data->user), $data->token);
+
+        $this->assertEquals(1, $data->token->fresh()->visits);
+    }
+
+    public function test_it_deletes_the_token_after_the_specified_amount_of_logins()
+    {
+        config()->set('login-links.route.allowed_visits_before_expiration', 1);
+
+        $data = $this->createUrlAndToken();
+
+        LoginLink::login($data->user->id, get_class($data->user), $data->token);
+
+        $this->assertNull($data->token->fresh());
+    }
+
+    public function test_it_can_still_login_after_the_first_time_if_allowed_visits_is_more_than_one()
+    {
+        config()->set('login-links.route.allowed_visits_before_expiration', 2);
+
+        $data = $this->createUrlAndToken();
+
+        LoginLink::login($data->user->id, get_class($data->user), $data->token->fresh());
+
+        \Auth::logout();
+
+        LoginLink::login($data->user->id, get_class($data->user), $data->token->fresh());
+
+        $this->assertAuthenticatedAs($data->user);
+
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -113,7 +113,7 @@ class TestCase extends Orchestra
         $url = $this->createUrl($user);
         $token = $this->getToken($url);
 
-        return (object) ['user' => $user, 'url' =>  $url, 'token' => $token];
+        return (object) ['user' => $user, 'url' => $url, 'token' => $token];
     }
 
     protected function between($starting_word, $ending_word, $string)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -92,6 +92,30 @@ class TestCase extends Orchestra
         ])->save();
     }
 
+    public function getUser()
+    {
+        return User::inRandomOrder()->first();
+    }
+
+    public function createUrl($user)
+    {
+        return $user->generateLoginLink();
+    }
+
+    public function getToken($url)
+    {
+        return LoginLinkToken::where('url', $url)->first();
+    }
+
+    public function createUrlAndToken()
+    {
+        $user = $this->getUser();
+        $url = $this->createUrl($user);
+        $token = $this->getToken($url);
+
+        return (object) ['user' => $user, 'url' =>  $url, 'token' => $token];
+    }
+
     protected function between($starting_word, $ending_word, $string)
     {
         $arr = explode($starting_word, $string);

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -9,28 +9,28 @@ class UrlTest extends TestCase
 {
     public function test_it_generates_a_valid_signed_url()
     {
-        $user = User::first();
-        $url = LoginLink::generate($user);
 
-        $this->assertIsValidLoginUrl($url, $user);
+        $data = $this->createUrlAndToken();
+
+        $this->assertIsValidLoginUrl($data->url, $data->user);
     }
 
     public function test_the_user_cannot_be_changed_after_generating_the_url()
     {
-        $user = User::inRandomOrder()->first();
+
+        $data = $this->createUrlAndToken();
 
         $otherUser = User::inRandomOrder()
-            ->where('id', '!=', $user->id)
+            ->where('id', '!=', $data->user->id)
             ->first();
 
-        $url = LoginLink::generate($user);
 
-        $badUrl = str_replace('auth_id=' . $user->id, 'auth_id=' . $otherUser->id, $url);
+        $badUrl = str_replace('auth_id=' . $data->user->id, 'auth_id=' . $otherUser->id, $data->url);
 
         $this->get($badUrl)
             ->assertForbidden();
 
-        $this->get($url . 'added')
+        $this->get($data->url . 'added')
             ->assertForbidden();
 
         $this->assertGuest();

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -2,14 +2,12 @@
 
 namespace Koost89\LoginLinks\Tests;
 
-use Koost89\LoginLinks\Facades\LoginLink;
 use Koost89\LoginLinks\Tests\TestClasses\User;
 
 class UrlTest extends TestCase
 {
     public function test_it_generates_a_valid_signed_url()
     {
-
         $data = $this->createUrlAndToken();
 
         $this->assertIsValidLoginUrl($data->url, $data->user);
@@ -17,7 +15,6 @@ class UrlTest extends TestCase
 
     public function test_the_user_cannot_be_changed_after_generating_the_url()
     {
-
         $data = $this->createUrlAndToken();
 
         $otherUser = User::inRandomOrder()


### PR DESCRIPTION
This allows users to specify the amount of times a URL can be visited before it's expired, the default will still be one.